### PR TITLE
Inadvertent code cleanup

### DIFF
--- a/DODropletManager/Droplet.m
+++ b/DODropletManager/Droplet.m
@@ -22,10 +22,6 @@
         _name = [dictionary objectForKey:@"name"];
         _ip = [[[[dictionary objectForKey:@"networks"] objectForKey:@"v4"] objectAtIndex:index] objectForKey:@"ip_address"];
         _dropletID = [dictionary objectForKey:@"id"];
-//        _imageID = [dictionary objectForKey:@"image_id"];
-//        _sizeID = [dictionary objectForKey:@"size_id"];
-//        _regionID = [dictionary objectForKey:@"region_id"];
-//        _privateIP = [dictionary objectForKey:@"private_ip_address"];
         _createdAt = [dictionary objectForKey:@"created_at"];
         _status = [[dictionary objectForKey:@"status"] uppercaseString];
         

--- a/DODropletManager/DropletFormWindowController.m
+++ b/DODropletManager/DropletFormWindowController.m
@@ -173,7 +173,6 @@
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection
 {
-    NSError *error;
     NSDictionary* json;
 
     if([connection isEqual:createNewDropletConnection])

--- a/DODropletManager/DropletFormWindowController.m
+++ b/DODropletManager/DropletFormWindowController.m
@@ -88,12 +88,6 @@
     newDroplet.regionID = regionID;
     
     [dropletManager requestCreateDroplet:newDroplet];
-    
-//    NSString *path = [NSString stringWithFormat:@"https://api.digitalocean.com/droplets/new/?client_id=%@&api_key=%@&name=%@&size_id=%@&image_id=%@&region_slug=%@", clientID, APIKey, [self.dropletNameField.stringValue urlEncode], sizeID, imageID, regionID];
-    
-//    NSURL *url = [NSURL URLWithString:path];
-//    NSURLRequest *urlRequest = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:30.0];
-//    createNewDropletConnection = [[NSURLConnection alloc] initWithRequest:urlRequest delegate:self];
 }
 
 - (void)cancelDroplet:(id)sender

--- a/DODropletManager/DropletManager.m
+++ b/DODropletManager/DropletManager.m
@@ -480,7 +480,6 @@
 
         } else  if (connection == rebootDropletConnection) {
             DLog(@"Results :%@", json);
-//            DLog(@"Result status %@", [json objectForKey:@"status"]);
 
         } else  if (connection == shutdownDropletConnection) {
             DLog(@"Result status %@", json);
@@ -489,10 +488,8 @@
             DLog(@"Result status %@", json);
 
         } else if (connection == deleteDropletConnection) {
-//            [self refreshDroplets];
             DLog(@"Result status %@", json);
         } else if (connection == createDropletConnection) {
-            //            [self refreshDroplets];
             DLog(@"Result status %@", json);
         }
     }

--- a/DODropletManager/PreferencesWindow.xib
+++ b/DODropletManager/PreferencesWindow.xib
@@ -8,14 +8,12 @@
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesWindowController">
             <connections>
                 <outlet property="accountNameLB" destination="pkc-9S-kCd" id="8BH-VH-lwd"/>
-                <outlet property="checkLaunchAtLogin" destination="KD1-dT-rrM" id="cll-pU-bt6"/>
                 <outlet property="iTermCB" destination="2hf-Rh-gUd" id="Va5-sg-1Xk"/>
                 <outlet property="launchAtLoginCB" destination="KD1-dT-rrM" id="tpD-oB-epf"/>
                 <outlet property="linkAccountBT" destination="U09-XW-9Aa" id="yJe-n5-Y9G"/>
                 <outlet property="publicIPsCB" destination="QG9-Wc-ZbG" id="aHo-JD-fsX"/>
                 <outlet property="sshUsersTableview" destination="DYV-7b-R4f" id="vsR-G4-qcB"/>
                 <outlet property="statusLB" destination="xxQ-Fx-vOU" id="Szj-nc-Ro5"/>
-                <outlet property="tokenLB" destination="NEJ-Wc-cO8" id="DxW-4r-hFO"/>
                 <outlet property="versionLabel" destination="4uE-tQ-30Y" id="ESY-GI-H41"/>
             </connections>
         </customObject>
@@ -320,7 +318,6 @@
             <size key="contentSize" width="100" height="100"/>
             <size key="maxContentSize" width="10000" height="10000"/>
         </drawer>
-        <customObject id="fYl-oT-ujy" customClass="SUUpdater"/>
         <button verticalHuggingPriority="750" id="dhH-Xi-OKp">
             <rect key="frame" x="0.0" y="0.0" width="94" height="43"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>

--- a/DODropletManager/PreferencesWindowController.h
+++ b/DODropletManager/PreferencesWindowController.h
@@ -29,9 +29,6 @@
 
 @property (weak) IBOutlet NSTextField *versionLabel;
 
-@property (weak) IBOutlet NSTextField *tokenLB;
-
-
 
 - (BOOL) checkiTerm;
 

--- a/DODropletManager/PreferencesWindowController.m
+++ b/DODropletManager/PreferencesWindowController.m
@@ -108,9 +108,6 @@
         [_publicIPsCB setState:NSOffState];
 
     dropletManager.delegate = self;
-    
-    [_tokenLB setStringValue:dropletManager.accessToken];
-    
 
     if ([dropletManager isConnectionSuccessful]) {
         [_statusLB setStringValue:@"Connected"];

--- a/DODropletManager/PreferencesWindowController.m
+++ b/DODropletManager/PreferencesWindowController.m
@@ -84,14 +84,6 @@
         [self.versionLabel setStringValue:@""];
     }
     
-//    if([KeychainAccess getClientId: &clientId andAPIKey: &apiKey error: nil]) {
-//        [_ClientIDTF setStringValue: clientId];
-//        [_APIKeyTF setStringValue: apiKey];
-//    }
-    
-    
-
-    
     [self registerAppURL];
 
 
@@ -343,8 +335,6 @@
         
         
     }
-    
-//    cellView.objectValue = cellView.textField;
     
     [userdefaults setObject:sshUserDictionary forKey:@"sshUserDictionary"];
     [userdefaults setObject:sshPortDictionary forKey:@"sshPortDictionary"];


### PR DESCRIPTION
Thanks for merging my previous PR! Initially, I was trying to figure out why my builds wouldn't allow me to get an access token from DigitalOcean, so I cleaned up most of the debug warnings/errors until I eventually determined that you have a client id and secret that you set when you build the binary (derp). 

In any case, it seems to work pretty well - my changes should have no effect on the app besides the less spurious debug log and slight improvement to code readability. 

Only thing I noticed while using your droplet manager is that it consistently crashes when attempting to get the currentTerminal for iTerm. Normally i would create an issue for this sort of thing, but I am running MacOS Sierra and Xcode 8 beta, so really this is just good news that your applet builds and runs almost flawlessly on the initial DP of the next MacOS release. Thanks again for your great work!
