### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inspired by Andrewsomething's [DigitalOcean Indicator](http://blog.andrewsomethi
 - Open a SSH session to droplets
  
 
-##License
+## License
 DigitalOcean Droplets Manager for OSX Copyright (C) 2014 David Hsieh
 
     This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
